### PR TITLE
Downgrade back to shapeless-2.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val catsCoreVersion = "1.1.0"
 val catsEffectVersion = "0.10.1"
 val catsMtlVersion = "0.2.3"
 val scalatest = "3.0.4"
-val shapeless = "2.3.3"
+val shapeless = "2.3.2"
 val scalacheck = "1.13.5"
 
 lazy val root = Project("frameless", file("." + "frameless")).in(file("."))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-frmn-1"
+version in ThisBuild := "0.4.1-frmn-2"


### PR DESCRIPTION
shapeless-2.3.3 is used by few of our dependencies.  Getting our unit tests that use frameless to use the shaded version of shapeless is a tar pit.  So we'll explicitly shade shapeless-2.3.3 in those few dependencies, and keep frameless in its natural dependency.

This negates most of the utility of our fork, but it does eliminate a few warnings about cats.  And I think we're going to need this fork for cats-effect-1.0 anyway, unless we're on a newer Spark across the board by then.